### PR TITLE
Feature/014

### DIFF
--- a/api/inventory/urls.py
+++ b/api/inventory/urls.py
@@ -3,5 +3,7 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path('products/', views.ProductView.as_view())
+    path('products/', views.ProductView.as_view()),
+    path('products/model/',
+         views.ProductModelViewSet.as_view({'get': 'list'})),
 ]

--- a/api/inventory/views.py
+++ b/api/inventory/views.py
@@ -1,6 +1,7 @@
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from rest_framework.viewsets import ModelViewSet
 
 from .models import Product
 from .serializers import ProductSerializer
@@ -11,3 +12,8 @@ class ProductView(APIView):
         queryset = Product.objects.all()
         serializer = ProductSerializer(queryset, many=True)
         return Response(serializer.data, status.HTTP_200_OK)
+
+
+class ProductModelViewSet(ModelViewSet):
+    queryset = Product.objects.all()
+    serializer_class = ProductSerializer


### PR DESCRIPTION
このプルリクエストは、商品データをより堅牢かつ標準化された方法で処理できるように、inventory APIに新しい`ProductModelViewSet`を導入します。また、モデルビューセットにアクセスするための新しいエンドポイントを含めるようにURL構成を更新します。

### APIの機能強化:

* **新しい`ProductModelViewSet`クラス**: `Product`モデル用の組み込みCRUD操作を提供する`ModelViewSet`実装を`api/inventory/views.py`に追加しました。これは、クエリセットとして`Product.objects.all()`を使用し、シリアライズに`ProductSerializer`を使用します。
* **更新されたURLパターン**: 商品をリストするための`GET`メソッドを備えた`ProductModelViewSet`を公開するために、`api/inventory/urls.py`に新しいルート(`products/model/`)を追加しました。

### 依存関係の更新:

* **`ModelViewSet`のインポート**: 新しいビューセット機能をサポートするために、`api/inventory/views.py`に`rest_framework.viewsets`からの`ModelViewSet`のインポートを追加しました。