### PR TITLE
APIのエンドポイントになるURLの設定を追加しよう

### DIFF
--- a/api/inventory/urls.py
+++ b/api/inventory/urls.py
@@ -4,6 +4,7 @@ from . import views
 
 urlpatterns = [
     path('products/', views.ProductView.as_view()),
+    path('products/<int:id>/', views.ProductView.as_view()),
     path('products/model/',
          views.ProductModelViewSet.as_view({'get': 'list', 'post': 'create'})),
     path('purchases/', views.PurchaseView.as_view()),


### PR DESCRIPTION
このプルリクエストは、`api/inventory/urls.py`ファイルへの小さな更新を含み、商品関連のエンドポイントのルーティングを強化します。

* 特定の商品をIDで取得または操作できるようにする新しいURLパターンを追加しました (`path('products/<int:id>/')`)。