### PR TITLE
APIViewによる削除

### DIFF
--- a/api/inventory/views.py
+++ b/api/inventory/views.py
@@ -51,6 +51,14 @@ class ProductView(APIView):
         serializer.save()
         return Response(serializer.data, status.HTTP_200_OK)
 
+    def delete(self, request, id, format=None):
+        """
+        商品情報を削除する
+        """
+        product = self.get_object(id)
+        product.delete()
+        return Response(status=status.HTTP_200_OK)
+
 
 class ProductModelViewSet(ModelViewSet):
     queryset = Product.objects.all()


### PR DESCRIPTION
このプルリクエストは、`api/inventory/views.py`ファイルに新しい`delete`メソッドを追加し、API経由での商品情報の削除を可能にします。

主な変更点:

* `ProductView`クラスに`delete`メソッドを追加し、IDによる商品の削除を可能にしました。このメソッドは、`get_object`を使用して商品を取得し、削除して、200 OKレスポンスを返します。