### PR TITLE
プログラムでデータを参照するためのAPIファイルへの処理を追加しよう

### DIFF
--- a/api/inventory/views.py
+++ b/api/inventory/views.py
@@ -1,11 +1,17 @@
+from django.db.models import F, Value
 from rest_framework import status
 from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.viewsets import ModelViewSet
 
-from .models import Product
-from .serializers import ProductSerializer, PurchaseSerializer, SaleSerializer
+from .models import Product, Purchase, Sales
+from .serializers import (
+    InventorySerializer,
+    ProductSerializer,
+    PurchaseSerializer,
+    SaleSerializer,
+)
 
 
 class ProductView(APIView):
@@ -85,3 +91,20 @@ class SalesView(APIView):
         serializer.is_valid(raise_exception=True)
         serializer.save()
         return Response(serializer.data, status.HTTP_201_CREATED)
+
+
+class InventoryView(APIView):
+    # 仕入れ・売上情報を取得する
+    def get(self, request, id=None, format=None):
+        if id is None:
+            # 件数が多くなるので商品IDは必ず指定する
+            return Response({}, status.HTTP_400_BAD_REQUEST)
+        else:
+            # UNIONするために、それぞれフィールド名を再定義している
+            purchase = Purchase.objects.filter(product_id=id).prefetch_related('product').values(
+                "id", "quantity", type=Value('1'), date=F('purchase_date'), unit=F('product__price'))
+            sales = Sales.objects.filter(product_id=id).prefetch_related('product').values(
+                "id", "quantity", type=Value('2'), date=F('sales_date'), unit=F('product__price'))
+            queryset = purchase.union(sales).order_by(F("date"))
+            serializer = InventorySerializer(queryset, many=True)
+        return Response(serializer.data, status.HTTP_200_OK)


### PR DESCRIPTION
このプルリクエストは、在庫関連の操作を処理するための新しい`InventoryView`クラスを導入し、`api/inventory/views.py`ファイルのインポートをリファクタリングします。これらの変更により、特定の製品の購入データと販売データを取得できるようになり、機能が向上し、コードの整理が強化されます。

### 新機能:

* `api/inventory/views.py`に`InventoryView`クラスを追加し、結合クエリを使用して特定の製品の購入情報と販売情報を取得するようにしました。これにより、両方のタイプのデータが結合され、日付で並べ替えられます。このビューでは、製品IDの指定が必要であり、指定されていない場合は`400 BAD REQUEST`ステータスを返します。

### コードの整理:

* `api/inventory/views.py`のインポートをリファクタリングし、`django.db.models`から`F`と`Value`を含め、`Purchase`、`Sales`、および`InventorySerializer`を含むようにモデルとシリアライザーのインポートを更新しました。これにより、新しい機能に必要なすべてのコンポーネントがインポートされます。