### PR TITLE
Djangoサーバーがライブラリを読み込むように設定する

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = [
     "rest_framework",
     "corsheaders",
     "api.inventory",
+    "drf_yasg",
 ]
 
 MIDDLEWARE = [

--- a/requirements.lock
+++ b/requirements.lock
@@ -2,8 +2,14 @@ asgiref==3.8.1
 Django==5.2
 django-cors-headers==4.7.0
 djangorestframework==3.16.0
+drf-yasg==1.21.10
 gitdb==4.0.12
 GitPython==3.1.41
+inflection==0.5.1
+packaging==25.0
+pytz==2025.2
+PyYAML==6.0.2
 setuptools==75.6.0
 smmap==5.0.2
 sqlparse==0.5.3
+uritemplate==4.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 djangorestframework
 django-cors-headers
+drf-yasg


### PR DESCRIPTION
このプルリクエストは、`config/settings.py`ファイルに小さな変更を加えます。この変更は、インストール済みアプリのリストに`drf_yasg`ライブラリを追加し、APIのOpenAPIスキーマ生成とSwagger UIを有効にします。