### PR TITLE
Djangoで共通設定のAPIへのルーティングを設定する

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -1,24 +1,22 @@
-"""
-URL configuration for config project.
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/5.2/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  path('', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.urls import include, path
-    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
-"""
-
 from django.contrib import admin
 from django.urls import include, path
+from drf_yasg import openapi
+from drf_yasg.views import get_schema_view
+from rest_framework.permissions import AllowAny
+
+schema_view = get_schema_view(
+    openapi.Info(
+        title="Inventory API",
+        default_version='v1',
+        description="API documentation for Inventory management",
+    ),
+    public=True,
+    permission_classes=(AllowAny,),
+)
 
 urlpatterns = [
     # path("admin/", admin.site.urls),
     path('api/inventory/', include('api.inventory.urls')),
+    path('swagger/', schema_view.with_ui('swagger',
+         cache_timeout=0), name='schema-swagger-ui'),
 ]


### PR DESCRIPTION
このプルリクエストは、Swaggerを使用してAPIドキュメントを統合し、古いコメントを削除するために、`config/urls.py`ファイルを更新します。この統合により、Inventory APIを探索するためのユーザーフレンドリーなインターフェースが提供されます。

**APIドキュメントの統合:**

* `drf_yasg`をインポートし、Inventory APIのスキーマビューを構成することで、Swaggerサポートを追加しました。これには、タイトル、バージョン、説明などのAPIメタデータの定義が含まれます。(`[config/urls.pyL1-R21](diffhunk://#diff-50a97044da6c03473bbe6aa0042347bbef6303547d3b7bf85e1e5eb8f07cf428L1-R21)`)
* `/swagger/`エンドポイントでSwagger UIにアクセスするための新しいURLパターンを追加しました。(`[config/urls.pyL1-R21](diffhunk://#diff-50a97044da6c03473bbe6aa0042347bbef6303547d3b7bf85e1e5eb8f07cf428L1-R21)`)

**コードのクリーンアップ:**

* URL構成の例に関連する古いコメントを削除し、ファイルを簡素化しました。(`[config/urls.pyL1-R21](diffhunk://#diff-50a97044da6c03473bbe6aa0042347bbef6303547d3b7bf85e1e5eb8f07cf428L1-R21)`)