### PR TITLE
データベースの売上数を年月ごとに返却する

### DIFF
--- a/api/inventory/serializers.py
+++ b/api/inventory/serializers.py
@@ -31,3 +31,8 @@ class InventorySerializer(serializers.Serializer):
 
 class FileSerializer(serializers.Serializer):
     file = serializers.FileField()
+
+
+class SalesSerializer(serializers.Serializer):
+    monthly_date = serializers.DateTimeField(format='%Y-%m')
+    monthly_price = serializers.IntegerField()

--- a/api/inventory/urls.py
+++ b/api/inventory/urls.py
@@ -12,4 +12,5 @@ urlpatterns = [
     path('inventories/<int:id>/', views.InventoryView.as_view()),
 
     path('sync/', views.SalesSyncView.as_view()),
+    path('summary/', views.SalesList.as_view()),
 ]

--- a/api/inventory/views.py
+++ b/api/inventory/views.py
@@ -173,6 +173,6 @@ class SalesSyncView(APIView):
 
 
 class SalesList(ListAPIView):
-    queryset = Sale.objects.annotate(monthly_date=TruncMonth('sales_date')).values(
+    queryset = Sale.objects.annotate(monthly_date=TruncMonth('sale_date')).values(
         'monthly_date').annotate(monthly_price=Sum('quantity')).order_by('monthly_date')
     serializer_class = SalesSerializer

--- a/api/inventory/views.py
+++ b/api/inventory/views.py
@@ -1,11 +1,12 @@
 import pandas as pd
 from django.db import transaction
 from django.db.models import F, Sum, Value
-from django.db.models.functions import Coalesce
+from django.db.models.functions import Coalesce, TruncMonth
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
 from rest_framework.exceptions import NotFound
+from rest_framework.generics import ListAPIView
 from rest_framework.parsers import MultiPartParser
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -19,6 +20,7 @@ from .serializers import (
     ProductSerializer,
     PurchaseSerializer,
     SaleSerializer,
+    SalesSerializer,
 )
 
 
@@ -168,3 +170,9 @@ class SalesSyncView(APIView):
         Sale.objects.bulk_create(sales)
 
         return Response(status=201)
+
+
+class SalesList(ListAPIView):
+    queryset = Sale.objects.annotate(monthly_date=TruncMonth('sales_date')).values(
+        'monthly_date').annotate(monthly_price=Sum('quantity')).order_by('monthly_date')
+    serializer_class = SalesSerializer


### PR DESCRIPTION
このプルリクエストでは、月ごとの売上データを集計する新機能を追加し、それに関連するシリアライザー、ビュー、URL構成の更新も行っています。主な変更点は、`SalesSerializer` の追加、月次売上のサマリーを返す `SalesList` ビューの作成、そしてそれに対応するURLパターンの更新です。

### 機能: 月次売上サマリー

* **新しい `SalesSerializer` の追加**
  月ごとの売上データを整形するためのシリアライザーを追加しました。フィールドには、`monthly_date`（`%Y-%m` 形式の日付）と `monthly_price`（整数型）が含まれます。
  （`api/inventory/serializers.py`, [[api/inventory/serializers.pyR34-R38](diffhunk://#diff-6b74cc2f2bffa2d4eee9e1e2fd1b697b23200cc95658b3462fcd78b0dc276520R34-R38)](diffhunk://#diff-6b74cc2f2bffa2d4eee9e1e2fd1b697b23200cc95658b3462fcd78b0dc276520R34-R38)）

* **新しい `SalesList` ビュー**
  `ListAPIView` を使って、月ごとの売上集計を計算・返却するビューを追加しました。`TruncMonth` を用いて売上を月単位でグループ化し、各月の売上合計（`monthly_price`）を算出しています。
  （`api/inventory/views.py`, [[api/inventory/views.pyR173-R178](diffhunk://#diff-76c2adb4f7e1288c356edf83f9ea0c826185d3fd754f2a09690cbd72552a03a2R173-R178)](diffhunk://#diff-76c2adb4f7e1288c356edf83f9ea0c826185d3fd754f2a09690cbd72552a03a2R173-R178)）

### 補助的な変更

* **URLパターンの更新**
  `SalesList` ビューを公開するため、新しいエンドポイント `summary/` をURL設定に追加しました。
  （`api/inventory/urls.py`, [[api/inventory/urls.pyR15](diffhunk://#diff-661f737bde3bdd3e02a901ae57d9fd0cf97816403fd2f97c0ba60eecb9332c8fR15)](diffhunk://#diff-661f737bde3bdd3e02a901ae57d9fd0cf97816403fd2f97c0ba60eecb9332c8fR15)）

* **インポートの追加**
  `TruncMonth` と `SalesSerializer` を使用するために、必要なインポートを `views.py` に追加しました。
  （`api/inventory/views.py`, [\[1\]](diffhunk://#diff-76c2adb4f7e1288c356edf83f9ea0c826185d3fd754f2a09690cbd72552a03a2L4-R9) [\[2\]](diffhunk://#diff-76c2adb4f7e1288c356edf83f9ea0c826185d3fd754f2a09690cbd72552a03a2R23)）

---

他に翻訳したい内容や、コードの補足説明が必要であれば教えてください。